### PR TITLE
Remove cssify as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,16 +28,6 @@
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-view-live",
-  "browser": {
-    "transform": [
-      "cssify"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "cssify"
-    ]
-  },
   "keywords": [
     "CanJS",
     "DoneJS"
@@ -70,7 +60,6 @@
     "can-map": "^3.0.0-pre.1",
     "bit-docs": "0.0.6",
     "jshint": "^2.9.1",
-    "cssify": "^0.6.0",
     "steal": "^0.16.0",
     "steal-qunit": "^0.1.1",
     "steal-tools": "^0.16.0",


### PR DESCRIPTION
cssify is not used in this project, and by including it, it breaks
Browserify