### PR TITLE
Making sure add / remove calls are applied in the order they were called

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -1,4 +1,6 @@
 var live = require('./core');
+var makeRunInOrder = require('./util/runInOrder');
+var runInOrder = makeRunInOrder();
 
 var nodeLists = require('can-view-nodelist');
 var makeCompute = require('can-compute');
@@ -118,7 +120,7 @@ live.list = function (el, compute, render, context, parentNode, nodeList, falsey
 		// A 'perfect' fix would be to use linked lists for event handlers.
 		isTornDown = false,
 		// Called when items are added to the list.
-		add = function (ev, items, index) {
+		add = runInOrder(function add (ev, items, index) {
 
 			if (!afterPreviousEvents) {
 				return;
@@ -186,14 +188,14 @@ live.list = function (el, compute, render, context, parentNode, nodeList, falsey
 				live.callChildMutationCallback(text.parentNode);
 			}
 
-		},
+		}),
 		// Called when an item is set with .attr
 		set = function(ev, newVal, index) {
 			remove({}, { length: 1 }, index, true);
 			add({}, [newVal], index);
 		},
 		// Called when items are removed or when the bindings are torn down.
-		remove = function (ev, items, index, duringTeardown, fullTeardown) {
+		remove = runInOrder(function remove (ev, items, index, duringTeardown, fullTeardown) {
 
 			if (!afterPreviousEvents) {
 				return;
@@ -226,7 +228,7 @@ live.list = function (el, compute, render, context, parentNode, nodeList, falsey
 			} else {
 				nodeLists.unregister(masterNodeList);
 			}
-		},
+		}),
 		move = function (ev, item, newIndex, currentIndex) {
 			if (!afterPreviousEvents) {
 				return;

--- a/lib/util/runInOrder.js
+++ b/lib/util/runInOrder.js
@@ -1,0 +1,29 @@
+module.exports = function makeRunInOrder() {
+	var running = 0;
+	var tasks = [];
+
+	return function runInOrder(fn) {
+		return function() {
+			var fnArgs = arguments;
+
+			if (running) {
+				tasks.push({
+					fn: fn,
+					args: fnArgs
+				});
+				return;
+			}
+
+			running++;
+			fn.apply(null, fnArgs);
+			running--;
+
+			while (tasks.length) {
+				running++;
+				tasks[0].fn.apply(null, tasks[0].args);
+				tasks.shift();
+				running--;
+			}
+		};
+	};
+};


### PR DESCRIPTION
Previously if `add` was called and then `remove` was called within the
same batch, the batch could be flushed during the `render` of the `add`
which would cause the `remove` to be applied first. This changed makes
sure that any calls to `add` or `remove` do not start running until all
previous calls have completed.

Closes https://github.com/canjs/can-view-live/issues/8.