### PR TITLE
registering `live.attr`s with can-view-nodelist so bindings can be torn down when unregistered

### DIFF
--- a/lib/attr.js
+++ b/lib/attr.js
@@ -1,10 +1,11 @@
 var attr = require('can-util/dom/attr/attr');
+var nodeLists = require('can-view-nodelist');
 var live = require('./core');
 /**
  * @function can-view-live.attr attr
  * @parent can-view-live
  *
- * @signature `live.attr(el, attributeName, compute)`
+ * @signature `live.attr(el, attributeName, compute, nodeList)`
  *
  * Keep an attribute live to a [can-compute].
  *
@@ -17,11 +18,29 @@ var live = require('./core');
  * @param {HTMLElement} el The element whos attribute will be kept live.
  * @param {String} attributeName The attribute name.
  * @param {can-compute} compute The compute.
+ * @param {can-view-nodelist} nodeList The
  *
  */
-live.attr = function(el, attributeName, compute){
-	live.listen(el, compute, function (ev, newVal) {
+live.attr = function(el, attributeName, compute, nodeList){
+	var origUnregistered;
+
+	var data = live.listen(el, compute, function (ev, newVal) {
 		attr.set(el, attributeName, newVal);
 	});
 	attr.set(el, attributeName, compute());
+
+	// register the element so can-view-nodelist can unregister its event handler
+	// when the nodeList is unregistered
+	if(!nodeList) {
+		nodeLists.register([ el ], data.teardownCheck);
+	} else {
+		// unregistered may already exist if this element is within a live html section
+		origUnregistered = nodeList.unregistered;
+		nodeList.unregistered = function() {
+			data.teardownCheck();
+			if (origUnregistered) {
+				origUnregistered();
+			}
+		};
+	}
 };

--- a/lib/html.js
+++ b/lib/html.js
@@ -37,7 +37,7 @@ var childNodes = require('can-util/dom/child-nodes/child-nodes');
  *
  */
 live.html = function (el, compute, parentNode, nodeList) {
-	var data;
+	var data, origUnregistered;
 	parentNode = live.getParentNode(el, parentNode);
 	data = live.listen(parentNode, compute, function (ev, newVal, oldVal) {
 		// TODO: remove teardownCheck in 2.1
@@ -71,11 +71,19 @@ live.html = function (el, compute, parentNode, nodeList) {
 
 	data.nodeList = nodes;
 
-	// register the span so nodeLists knows the parentNodeList
+	// register the span so can-view-nodelist can unregister its event handler
+	// when the nodeList is unregistered
 	if(!nodeList) {
 		nodeLists.register(nodes, data.teardownCheck);
 	} else {
-		nodeList.unregistered = data.teardownCheck;
+		// unregistered may already exist if this element has live attributes
+		origUnregistered = nodeList.unregistered;
+		nodeList.unregistered = function() {
+			data.teardownCheck();
+			if (origUnregistered) {
+				origUnregistered();
+			}
+		};
 	}
 	makeAndPut(compute());
 };

--- a/test/live-test.js
+++ b/test/live-test.js
@@ -403,3 +403,71 @@ test('list items should be correct even if renderer flushes batch (#8)', functio
 	equal(partial.getElementsByTagName('span')[0].firstChild.data, 'three', 'list item 0 is "three"');
 	equal(partial.getElementsByTagName('span')[1].firstChild.data, 'one', 'list item 1 is "one"');
 });
+
+test('live.html compute bindings are removed when parent nodeList is unregistered', function() {
+	var frag = document.createDocumentFragment(),
+		parentNode = document.createTextNode(''),
+		parentNodeList = nodeLists.register([ parentNode ], null, true, false);
+	frag.appendChild(parentNode);
+
+	var div = document.createElement('div'),
+		placeholder = document.createTextNode('');
+	div.appendChild(placeholder);
+
+	var htmlCompute = compute(function(){
+		return "<h1>Hello World</h1>";
+	});
+
+	live.html(placeholder, htmlCompute, div, parentNodeList);
+
+	nodeLists.unregister(parentNodeList);
+
+	equal(htmlCompute.computeInstance.__bindEvents._lifecycleBindings, 0, 'bindings are removed');
+});
+
+test('live.attr compute bindings are removed when parent nodeList is unregistered', function() {
+	var frag = document.createDocumentFragment(),
+		parentNode = document.createTextNode(''),
+		parentNodeList = nodeLists.register([ parentNode ], null, true, false);
+	frag.appendChild(parentNode);
+
+	var div = document.createElement('div');
+
+	var classCompute = compute(function(){
+		return "hello-class";
+	});
+
+	live.attr(div, "class", classCompute, parentNodeList);
+
+	nodeLists.unregister(parentNodeList);
+
+	equal(classCompute.computeInstance.__bindEvents._lifecycleBindings, 0, 'bindings are removed');
+});
+
+test('live.html and live.attr compute bindings are removed when parent nodeList is unregistered', function() {
+	var frag = document.createDocumentFragment(),
+		parentNode = document.createTextNode(''),
+		parentNodeList = nodeLists.register([ parentNode ], null, true, false);
+	frag.appendChild(parentNode);
+
+	var div = document.createElement('div'),
+		placeholder = document.createTextNode('');
+	div.appendChild(placeholder);
+
+	var classCompute = compute(function(){
+		return "hello-class";
+	});
+
+	live.attr(div, "class", classCompute, parentNodeList);
+
+	var htmlCompute = compute(function(){
+		return "<h1>Hello World</h1>";
+	});
+
+	live.html(placeholder, htmlCompute, div, parentNodeList);
+
+	nodeLists.unregister(parentNodeList);
+
+	equal(htmlCompute.computeInstance.__bindEvents._lifecycleBindings, 0, 'html bindings are removed');
+	equal(classCompute.computeInstance.__bindEvents._lifecycleBindings, 0, 'attr bindings are removed');
+});


### PR DESCRIPTION
Second piece of https://github.com/canjs/canjs/issues/3147.