### PR TITLE
chore(package): update can-event to version 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "can-compute": "^3.3.1",
-    "can-event": "^3.5.0-pre.2",
+    "can-event": "^3.6.0",
     "can-observation": "^3.3.1",
     "can-reflect": "^1.2.1",
     "can-types": "^1.1.0-pre.2",


### PR DESCRIPTION
Closes #35 