### PR TITLE
Fix live.list move event handling

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -68,7 +68,7 @@ removeFromNodeList = function(masterNodeList, index, length){
 	return itemsToRemove;
 },
 // #### addFalseyIfEmpty
-// Add the results of redering the "falsey" or inverse case render to the 
+// Add the results of redering the "falsey" or inverse case render to the
 // master nodeList and the DOM if the live list is empty
 addFalseyIfEmpty = function(list, falseyRender, masterNodeList, nodeList){
 	if(falseyRender && list.length === 0){
@@ -306,7 +306,7 @@ live.list = function (el, compute, render, context, parentNode, nodeList, falsey
 
 			for (i, len; i < len; i++) {
 				// set each compute to have its current index in the map as its value
-				indexMap[i](i);
+				indexMap[i].set(i);
 			}
 			if(ev.callChildMutationCallback !== false) {
 				// fire any registered mutation callback

--- a/test/live-test.js
+++ b/test/live-test.js
@@ -304,6 +304,30 @@ test("live.list does not unbind on a list unnecessarily (#1835)", function(){
 	live.list(el, list, template, {});
 });
 
+test('live.list should handle move events', function (assert) {
+	/*
+		All this test does is make sure triggering the move event
+		does not cause live.list to blow up.
+	*/
+	var parent = document.createElement('div');
+	var child = document.createElement('div');
+	parent.appendChild(child);
+	var list = new List([1, 2, 3]);
+	var template = function (num) {
+		return '<span>' + num + '</span>';
+	};
+
+	live.list(child, list, template, {});
+
+	var oldIndex = 0;
+	var newIndex = 2;
+	var val = list[oldIndex];
+	var args = [val, oldIndex, newIndex];
+	list.dispatch('move', args);
+
+	assert.ok(true, 'The list should not blow up');
+});
+
 test("can.live.attr works with non-string attributes (#1790)", function() {
 	var el = document.createElement('div'),
 		attrCompute = compute(function() {


### PR DESCRIPTION
This fixes `can-live-sort` which error-ed out with `indexMap[i] is not a function` as these are Computes.