### PR TITLE
Wait until events are removed from old list before assigning new list as old.

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -354,7 +354,6 @@ live.list = function (el, compute, render, context, parentNode, nodeList, falsey
 				list = newList || [];
 				// The minimal diff between lists
 				var patches = diff(oldList, newList);
-				oldList = newList;
 
 				// Tear down event bindings if old list is observable
 				if ( oldList.removeEventListener ) {
@@ -363,6 +362,7 @@ live.list = function (el, compute, render, context, parentNode, nodeList, falsey
 					oldList.removeEventListener('remove', queuedFns.remove);
 					oldList.removeEventListener('move', queuedFns.move);
 				}
+				oldList = newList;
 				for(var i = 0, patchLen = patches.length; i < patchLen; i++) {
 					var patch = patches[i];
 					if(patch.deleteCount) {

--- a/test/live-test.js
+++ b/test/live-test.js
@@ -615,4 +615,29 @@ QUnit.test('Works with Observations - .attr', function(){
 	equal(div.className, 'foo selected active end');
 	firstObject.attr('selected', false);
 	equal(div.className, 'foo  active end');
-})
+});
+
+QUnit.test("events are torn down from correct list on change", function() {
+	var div = document.createElement('div');
+	var list = new List([1, 2, 3]);
+	var filteredList;
+	var c = compute(list);
+
+
+		template = function (number) {
+			return '<label>Odd number=</label> <span>' + number.get() + '</span>';
+		};
+	div.innerHTML = 'my <b>fav</b> animals: <span></span> !';
+	var el = div.getElementsByTagName('span')[0];
+	live.list(el, c, template, {});
+	
+	ok(list.__bindEvents.add && list.__bindEvents.add.length > 0, "Add handler has been added to list");
+
+	c(filteredList = list.filter(function(x) {
+		return x % 2;
+	}));
+
+	ok(!list.__bindEvents.add || list.__bindEvents.add.length === 0, "Add handler has been removed from list");
+	ok(filteredList.__bindEvents.add && filteredList.__bindEvents.add.length > 0, "Add handler has been added to filteredList");
+});
+

--- a/test/live-test.js
+++ b/test/live-test.js
@@ -622,15 +622,13 @@ QUnit.test("events are torn down from correct list on change", function() {
 	var list = new List([1, 2, 3]);
 	var filteredList;
 	var c = compute(list);
-
-
-		template = function (number) {
-			return '<label>Odd number=</label> <span>' + number.get() + '</span>';
-		};
+	var template = function (number) {
+		return '<label>Odd number=</label> <span>' + number.get() + '</span>';
+	};
 	div.innerHTML = 'my <b>fav</b> animals: <span></span> !';
 	var el = div.getElementsByTagName('span')[0];
 	live.list(el, c, template, {});
-	
+
 	ok(list.__bindEvents.add && list.__bindEvents.add.length > 0, "Add handler has been added to list");
 
 	c(filteredList = list.filter(function(x) {


### PR DESCRIPTION
Fixes some errors I saw with unregistered nodeLists being updated in TodoMVC with can-observe.