### PR TITLE
Hide docs that can’t show up in the navigation

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -132,6 +132,7 @@ var live = {
 	 * @function can.view.live.replace
 	 * @parent can.view.live
 	 * @release 2.0.4
+	 * @hide
 	 *
 	 * Replaces one element with some content while keeping [can.view.live.nodeLists nodeLists] data
 	 * correct.


### PR DESCRIPTION
Should these be updated to `can-view-live`?

Part of https://github.com/canjs/canjs/issues/3660