### PR TITLE
Register element deps as mutate dependencies

### DIFF
--- a/lib/attrs.js
+++ b/lib/attrs.js
@@ -4,6 +4,7 @@ var viewCallbacks = require('can-view-callbacks');
 var attr = require('can-util/dom/attr/attr');
 var domEvents = require('can-util/dom/events/events');
 var canReflect = require('can-reflect');
+var mutateDeps = require('can-reflect-mutate-dependencies');
 
 live.attrs = function(el, compute, scope, options) {
 
@@ -62,7 +63,7 @@ live.attrs = function(el, compute, scope, options) {
 	Object.defineProperty(liveAttrsUpdate, "name", {
 		value: "live.attrs update::"+canReflect.getName(compute),
 	});
-	live.addElementDependency(el, compute);
+	mutateDeps.addMutatedBy(el, compute);
 	//!steal-remove-end
 
 	// set attributes on any change to the compute
@@ -73,7 +74,7 @@ live.attrs = function(el, compute, scope, options) {
 		domEvents.removeEventListener.call(el, 'removed', teardownHandler);
 
 		//!steal-remove-start
-		live.deleteElementDependency(el, compute);
+		mutateDeps.deleteMutatedBy(el, compute);
 		//!steal-remove-end
 	};
 	// unbind on element removal

--- a/lib/core.js
+++ b/lib/core.js
@@ -4,12 +4,9 @@ var nodeLists = require('can-view-nodelist');
 var makeFrag = require('can-util/dom/frag/frag');
 var childNodes = require('can-util/dom/child-nodes/child-nodes');
 var canReflect = require('can-reflect');
+var mutateDeps = require('can-reflect-mutate-dependencies');
 
 require('can-util/dom/events/removed/removed');
-
-// Maps DOM elements to the compute(s) they are bound to
-// { key :: Element, value :: Set<Observable> }
-var elementDependenciesMap = new WeakMap();
 
 /**
  * @module {{}} can-view-live can-view-live
@@ -77,14 +74,14 @@ var live = {
 				//compute.computeInstance.addEventListener('change', change);
 
 				//!steal-remove-start
-				live.addElementDependency(el, compute);
+				mutateDeps.addMutatedBy(el, compute);
 				//!steal-remove-end
 			},
 			function unbind(data) {
 				canReflect.offValue(compute, change, "notify");
 
 				//!steal-remove-start
-				live.deleteElementDependency(el, compute);
+				mutateDeps.deleteMutatedBy(el, compute);
 				//!steal-remove-end
 
 				//compute.computeInstance.removeEventListener('change', change);
@@ -166,50 +163,7 @@ var live = {
 	// any -> string converter (including nullish)
 	makeString: function(txt) {
 		return txt == null ? "" : "" + txt;
-	},
-
-	//!steal-remove-start
-	// ### addElementDependency
-	// Keeps track of the computes bound to the DOM element
-	addElementDependency: function(el, compute) {
-		var deps = elementDependenciesMap.get(el);
-
-		if (deps) {
-			deps.add(compute);
-		} else {
-			elementDependenciesMap.set(el, new Set([compute]));
-		}
-	},
-
-	// ### deleteElementDependency
-	// Deletes the given compute from the Set of computes bound to the
-	// DOM element; if the Set is empty, it removes the element from the
-	// internal 'elementDependenciesMap'
-	deleteElementDependency: function(el, compute) {
-		var deps = elementDependenciesMap.get(el);
-
-		if (deps) {
-			deps.delete(compute);
-			if (!deps.size) {
-				elementDependenciesMap.delete(el);
-			}
-		}
-	}
-	//!steal-remove-end
-};
-
-//!steal-remove-start
-var canSymbol = require('can-symbol');
-var getValueDependenciesSymbol = canSymbol.for('can.getValueDependencies');
-
-Element.prototype[getValueDependenciesSymbol] = function getValueDependencies() {
-	var el = this;
-	if (elementDependenciesMap.has(el)) {
-		return {
-			valueDependencies: elementDependenciesMap.get(el)
-		};
 	}
 };
-//!steal-remove-end
 
 module.exports = live;

--- a/lib/list.js
+++ b/lib/list.js
@@ -9,8 +9,9 @@ var childNodes = require('can-util/dom/child-nodes/child-nodes');
 var makeArray = require('can-util/js/make-array/make-array');
 var each = require('can-util/js/each/each');
 
-var canReflect = require("can-reflect");
 var canSymbol = require("can-symbol");
+var canReflect = require("can-reflect");
+var mutateDeps = require("can-reflect-mutate-dependencies");
 
 var SimpleObservable = require("can-simple-observable");
 var SetObservable = require("./set-observable");
@@ -136,7 +137,7 @@ ListDOMPatcher.prototype = {
 			this.addFalseyIfEmpty();
 		}
 		//!steal-remove-start
-		live.addElementDependency(this.parentNode, this.patcher.observableOrList);
+		mutateDeps.addMutatedBy(this.parentNode, this.patcher.observableOrList);
 		//!steal-remove-end
 	},
 	teardownValueBinding: function() {
@@ -146,7 +147,7 @@ ListDOMPatcher.prototype = {
 			length: this.patcher.currentList.length
 		}, 0, true);
 		//!steal-remove-start
-		live.deleteElementDependency(this.parentNode, this.patcher.observableOrList);
+		mutateDeps.deleteMutatedBy(this.parentNode, this.patcher.observableOrList);
 		//!steal-remove-end
 	},
 	onPatches: function ListDOMPatcher_onPatches(patches) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "can-observation": "^4.0.0-pre.3",
     "can-queues": "<2.0.0",
     "can-reflect": "^1.5.0",
+    "can-reflect-mutate-dependencies": "0.0.2",
     "can-simple-observable": "^2.0.0-pre.3",
     "can-symbol": "^1.4.1",
     "can-types": "^1.1.0",

--- a/test/attr-test.js
+++ b/test/attr-test.js
@@ -3,9 +3,9 @@ var Observation = require("can-observation");
 var QUnit = require('steal-qunit');
 var domAttr = require("can-util/dom/attr/attr");
 var SimpleObservable = require("can-simple-observable");
-var canReflect = require('can-reflect');
 var domEvents = require('can-util/dom/events/events');
 var testHelpers = require('can-test-helpers');
+var mutateDeps = require('can-reflect-mutate-dependencies');
 
 QUnit.module("can-view-live.attr",{
     setup: function(){
@@ -58,7 +58,7 @@ QUnit.test("can.live.attr works with non-string attributes (#1790)", function() 
 	ok(true, 'No exception thrown.');
 });
 
-testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
+testHelpers.dev.devOnlyTest('mutatedValueDependencies', function(assert) {
 	var done = assert.async();
 	assert.expect(2);
 
@@ -72,7 +72,7 @@ testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
 	live.attr(div, 'title', title);
 
 	assert.deepEqual(
-		canReflect.getValueDependencies(div).valueDependencies,
+		mutateDeps.getValueDependencies(div).mutatedValueDependencies,
 		new Set([id, title]),
 		'should return the two SimpleObservable as dependencies'
 	);
@@ -81,7 +81,7 @@ testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
 		domEvents.removeEventListener.call(div, 'removed', checkTeardown);
 
 		assert.equal(
-			typeof canReflect.getValueDependencies(div),
+			typeof mutateDeps.getValueDependencies(div),
 			'undefined',
 			'dependencies should be cleared out when elements is removed'
 		);

--- a/test/attrs-test.js
+++ b/test/attrs-test.js
@@ -5,8 +5,8 @@ var SimpleObservable = require("can-simple-observable");
 var queues = require("can-queues");
 var domEvents = require('can-util/dom/events/events');
 var domMutate = require('can-util/dom/mutate/mutate');
-var canReflect = require('can-reflect');
 var testHelpers = require('can-test-helpers');
+var mutateDeps = require('can-reflect-mutate-dependencies');
 
 QUnit.module("can-view-live.attrs",{
     setup: function(){
@@ -63,7 +63,7 @@ QUnit.test('should remove `removed` events listener', function () {
 	domMutate.removeChild.call(this.fixture, div);
 });
 
-testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
+testHelpers.dev.devOnlyTest('mutatedValueDependencies', function(assert) {
 	var done = assert.async();
 	assert.expect(2);
 
@@ -84,7 +84,7 @@ testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
 	live.attrs(div, text);
 
 	assert.deepEqual(
-		canReflect.getValueDependencies(div).valueDependencies,
+		mutateDeps.getValueDependencies(div).mutatedValueDependencies,
 		new Set([text])
 	);
 
@@ -92,7 +92,7 @@ testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
 		domEvents.removeEventListener.call(div, 'removed', checkTeardown);
 
 		assert.equal(
-			typeof canReflect.getValueDependencies(div),
+			typeof mutateDeps.getValueDependencies(div),
 			'undefined',
 			'dependencies should be cleared out when element is removed'
 		);

--- a/test/list-test.js
+++ b/test/list-test.js
@@ -12,6 +12,7 @@ var domMutate = require('can-util/dom/mutate/mutate');
 var canSymbol = require("can-symbol");
 var domEvents = require('can-util/dom/events/events');
 var testHelpers = require('can-test-helpers');
+var mutateDeps = require('can-reflect-mutate-dependencies');
 
 QUnit.module("can-view-live.list",{
 	setup: function(){
@@ -374,7 +375,7 @@ test("no memory leaks", function () {
 	},10);
 });
 
-testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
+testHelpers.dev.devOnlyTest('mutatedValueDependencies', function(assert) {
 	var done = assert.async();
 	assert.expect(2);
 
@@ -391,7 +392,7 @@ testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
 	live.list(el, list, template, {});
 
 	assert.deepEqual(
-		canReflect.getValueDependencies(div).valueDependencies,
+		mutateDeps.getValueDependencies(div).mutatedValueDependencies,
 		new Set([list])
 	);
 
@@ -399,7 +400,7 @@ testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
 		domEvents.removeEventListener.call(div, 'removed', checkTeardown);
 
 		assert.equal(
-			typeof canReflect.getValueDependencies(div),
+			typeof mutateDeps.getValueDependencies(div),
 			'undefined',
 			'dependencies should be cleared when parent node is removed'
 		);

--- a/test/text-test.js
+++ b/test/text-test.js
@@ -4,9 +4,9 @@ var QUnit = require('steal-qunit');
 var SimpleObservable = require("can-simple-observable");
 var domMutate = require('can-util/dom/mutate/mutate');
 var nodeLists = require('can-view-nodelist');
-var canReflect = require('can-reflect');
 var domEvents = require('can-util/dom/events/events');
 var testHelpers = require('can-test-helpers');
+var mutateDeps = require('can-reflect-mutate-dependencies');
 
 QUnit.module("can-view-live.text", {
 	setup: function() {
@@ -60,7 +60,7 @@ QUnit.test('text binding is memory safe (#666)', function() {
 	}, 100);
 });
 
-testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
+testHelpers.dev.devOnlyTest('mutatedValueDependencies', function(assert) {
 	var done = assert.async();
 	assert.expect(2);
 
@@ -82,7 +82,7 @@ testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
 	live.text(span, text, div);
 
 	assert.deepEqual(
-		canReflect.getValueDependencies(div).valueDependencies,
+		mutateDeps.getValueDependencies(div).mutatedValueDependencies,
 		new Set([text])
 	);
 
@@ -90,7 +90,7 @@ testHelpers.dev.devOnlyTest('getValueDependencies', function(assert) {
 		domEvents.removeEventListener.call(div, 'removed', checkTeardown);
 
 		assert.equal(
-			typeof canReflect.getValueDependencies(div),
+			typeof mutateDeps.getValueDependencies(div),
 			'undefined',
 			'dependencies should be clear out when elements is removed'
 		);


### PR DESCRIPTION
Removes statefulness from can-view-live

Closes #68 
