### PR TITLE
list manages the nodelist hierarchy itself, don't register a replacement

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -26,7 +26,7 @@ var renderAndAddToNodeLists = function(newNodeLists, parentNodeList, render, con
 	if(parentNodeList) {
 		// With a supplied parent list, "directly" register the new nodeList
 		//  as a child.
-		nodeLists.register(itemNodeList,null, parentNodeList, true);
+		nodeLists.register(itemNodeList, null, true, true);
 		itemNodeList.parentList = parentNodeList;
 		itemNodeList.expression = "#each SUBEXPRESSION";
 	}


### PR DESCRIPTION
This backports #94 to v3.x