### PR TITLE
using can-attribute-observable.set instead of setAttrOrProp

### DIFF
--- a/lib/attr.js
+++ b/lib/attr.js
@@ -30,7 +30,7 @@ var attr = require("can-attribute-observable/behaviors");
  */
 live.attr = function(el, attributeName, compute) {
 	function liveUpdateAttr(newVal) {
-		queues.domUIQueue.enqueue(attr.setAttrOrProp, attr, [el, attributeName, newVal]);
+		queues.domUIQueue.enqueue(attr.set, attr, [el, attributeName, newVal]);
 	}
 	// register that the handler changes the parent element
 	canReflect.assignSymbols(liveUpdateAttr, {
@@ -50,5 +50,5 @@ live.attr = function(el, attributeName, compute) {
 	live.listen(el, compute, liveUpdateAttr);
 
 	// do initial set of attribute as well
-	attr.setAttrOrProp(el, attributeName, canReflect.getValue(compute));
+	attr.set(el, attributeName, canReflect.getValue(compute));
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     ]
   },
   "dependencies": {
-    "can-attribute-observable": "^0.2.0",
+    "can-attribute-observable": "^0.2.1",
     "can-dom-mutate": "^1.0.0",
     "can-observation": "^4.0.0",
     "can-queues": "^1.0.0",


### PR DESCRIPTION
setAttrOrProp is (unoficially) deprecated since it now internally calls set.