### PR TITLE
Add support for can.viewInsert

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -4,7 +4,9 @@ var makeFrag = require('can-util/dom/frag/frag');
 var makeArray = require('can-util/js/make-array/make-array');
 var childNodes = require('can-util/dom/child-nodes/child-nodes');
 var canReflect = require('can-reflect');
+var canSymbol = require("can-symbol");
 var queues = require("can-queues");
+var viewInsertSymbol = canSymbol.for("can.viewInsert");
 
 /**
  * @function can-view-live.html html
@@ -38,10 +40,22 @@ var queues = require("can-queues");
  *
  *
  */
-live.html = function(el, compute, parentNode, nodeList) {
-	var data,
-		makeAndPut,
-		nodes;
+live.html = function(el, compute, parentNode, nodeListOrOptions) {
+	var data;
+	var makeAndPut;
+	var nodeList;
+	var nodes;
+	var options;
+
+	// nodeListOrOptions can either be a NodeList or an object with a nodeList property
+	if (nodeListOrOptions !== undefined) {
+		if (Array.isArray(nodeListOrOptions)) {
+			nodeList = nodeListOrOptions;
+		} else {
+			nodeList = nodeListOrOptions.nodeList;
+			options = nodeListOrOptions;
+		}
+	}
 
 	var meta = {reasonLog: "live.html replace::"+canReflect.getName(compute)};
 	// prefer to manipulate el's actual parent over the supplied parent
@@ -79,12 +93,21 @@ live.html = function(el, compute, parentNode, nodeList) {
 	nodes = nodeList || [el];
 	makeAndPut = function(val, useQueue) {
 		// ##### makeandput
-		// Receives the compute output (must be some DOM representation or a function)
-		var isFunction = typeof val === "function",
-			// translate val into a document fragment if it's DOM-like
-			frag = makeFrag(isFunction ? "" : val),
-			// previous set of nodes
-			oldNodes = makeArray(nodes);
+		// Receives the compute output (must be some DOM representation, a function,
+		// or an object with the can.viewInsert symbol)
+
+		// If val has the can.viewInsert symbol, call it and get something usable for val back
+		if (val && typeof val[viewInsertSymbol] === "function") {
+			val = val[viewInsertSymbol](options);
+		}
+
+		var isFunction = typeof val === "function";
+
+		// translate val into a document fragment if it's DOM-like
+		var frag = makeFrag(isFunction ? "" : val);
+
+		// previous set of nodes
+		var oldNodes = makeArray(nodes);
 
 		// Add a placeholder textNode if necessary.
 		live.addTextNodeIfNoChildren(frag);

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -7,6 +7,7 @@ var NodeLists = require("can-view-nodelist");
 var testHelpers = require('can-test-helpers');
 var domMutate = require('can-dom-mutate');
 var canReflectDeps = require('can-reflect-dependencies');
+var canSymbol = require('can-symbol');
 
 QUnit.module("can-view-live.html");
 
@@ -80,6 +81,26 @@ QUnit.test("Works with Observations - .html", function(){
 	equal(div.getElementsByTagName('label').length, 2);
 	items.push('three');
 	equal(div.getElementsByTagName('label').length, 3);
+});
+
+test("html live binding handles objects with can.viewInsert symbol", 2, function(assert) {
+	var div = document.createElement("div");
+	var options = {};
+	var placeholder = document.createTextNode("Placeholder text");
+	div.appendChild(placeholder);
+
+	var html = new Observation(function() {
+		return {
+			[canSymbol.for("can.viewInsert")]: function() {
+				assert.equal(arguments[0], options, "options were passed to symbol function");
+				return document.createTextNode("Replaced text");
+			}
+		};
+	});
+
+	live.html(placeholder, html, div, options);
+
+	assert.equal(div.textContent, "Replaced text", "symbol function called");
 });
 
 testHelpers.dev.devOnlyTest("child elements must disconnect before parents can re-evaluate", 1,function(){


### PR DESCRIPTION
This updates `html()` so it can accept an object with the can.viewInsert symbol as a property. The `html()` method also accepts an options object as the fourth argument; these options will be passed to the can.viewInsert symbol.

These changes are part of https://github.com/canjs/can-stache/issues/502