### PR TITLE
allows html updates to be queued multiple times within a batch

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -9,11 +9,16 @@ var queues = require("can-queues");
 var viewInsertSymbol = canSymbol.for("can.viewInsert");
 
 
-function updateNodeList(oldNodes, nodes, frag, nodeListUpdatedByFn) {
-	if(nodes.isUnregistered !== true) {
+function updateNodeList(data, frag, nodeListUpdatedByFn) {
+	if(data.nodeList.isUnregistered !== true) {
+		// We need to keep oldNodes up to date with the last fragment so if this
+		// function runs again, we can replace the oldNodes with frag
+		var newChildren = canReflect.toArray(childNodes(frag));
 		if(!nodeListUpdatedByFn) {
-			nodeLists.update(nodes, childNodes(frag), oldNodes);
+			nodeLists.update(data.nodeList, newChildren, data.oldNodes);
 		}
+		var oldNodes = data.oldNodes;
+		data.oldNodes = newChildren;
 		nodeLists.replace(oldNodes, frag);
 	}
 }
@@ -127,11 +132,10 @@ live.html = function(el, compute, parentNode, nodeListOrOptions) {
 
 		// Mark each node as belonging to the node list.
 
-		var oldNodes;
 		// DOM replace old nodes with new frag (which might contain some old nodes)
 		if(useQueue === true) {
 			// unregister all children immediately
-			oldNodes = nodeLists.unregisterChildren(nodes, true);
+			data.oldNodes = nodeLists.unregisterChildren(nodes, true);
 
 			var nodeListUpdatedByFn = false;
 			// allow
@@ -140,14 +144,14 @@ live.html = function(el, compute, parentNode, nodeListOrOptions) {
 				// see if nodes has already been updated
 				nodeListUpdatedByFn = nodeLists.first(nodes) === frag.firstChild;
 			}
-			queues.domUIQueue.enqueue(updateNodeList, null, [oldNodes, nodes, frag, nodeListUpdatedByFn], meta);
+			queues.domUIQueue.enqueue(updateNodeList, null, [data, frag, nodeListUpdatedByFn], meta);
 		} else {
 			// this is initialization, update right away.
-			oldNodes = nodeLists.update(nodes, childNodes(frag));
+			data.oldNodes = nodeLists.update(nodes, childNodes(frag));
 			if (isFunction) {
 				val(frag.firstChild);
 			}
-			nodeLists.replace(oldNodes, frag);
+			nodeLists.replace(data.oldNodes, frag);
 		}
 
 	};

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -230,7 +230,7 @@ QUnit.test(".html works if it is enqueued twice", function(){
 		html.set(fragment("<p>3</p>"));
 	},null,[]);
 
-	html.set(fragment("<p>2</p>"))
+	html.set(fragment("<p>2</p>"));
 	queues.batch.stop();
 	QUnit.ok(true, "got here without an error");
 

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -217,3 +217,24 @@ QUnit.test(".html works inside a .list (can-stache#542)", function(){
 
 	queues.batch.stop();
 });
+
+QUnit.test(".html works if it is enqueued twice", function(){
+	// enqueue in domUI right away and change again in there
+	var div = fragment("<div>PLACEHOLDER</div>").firstChild;
+	var html = new SimpleObservable(fragment("<p>1</p>"));
+
+	live.html(div.firstChild, html, div);
+
+	queues.batch.start();
+	queues.domUIQueue.enqueue(function setHTMLTO3(){
+		html.set(fragment("<p>3</p>"));
+	},null,[]);
+
+	html.set(fragment("<p>2</p>"))
+	queues.batch.stop();
+	QUnit.ok(true, "got here without an error");
+
+	QUnit.deepEqual(div.innerHTML.toLowerCase(), "<p>3</p>");
+
+
+});


### PR DESCRIPTION
Fixes a bug discovered here: https://github.com/m-mujica/nodelist-bug

There was a problem that the `oldNodes` array passed to `updateNodeList` was not consistent with changes made to the `nodeList` by previous calls to `updateNodeList`.

This makes `updateNodeList` update the `oldNodes` itself.

It does this by making the `data` maintained within `.html` include an `oldNodes`.  `oldNodes` should be an array of the last nodes that were used to update the page.
