### PR TITLE
Prefer document.contains over documentElement.contains

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -65,7 +65,10 @@ var live = {
 			}
 		};
 		removalDisposal = domMutate.onNodeRemoval(el, function () {
-			if (!el.ownerDocument.documentElement.contains(el)) {
+			var doc = el.ownerDocument;
+			var ownerNode = doc.contains ? doc : doc.documentElement;
+
+			if (!ownerNode.contains(el)) {
 				teardown();
 			}
 		});

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "can-define": "^2.0.0",
+    "can-globals": "^1.2.0",
     "can-simple-map": "^4.0.0",
     "can-test-helpers": "^1.1.0",
     "detect-cyclic-packages": "^1.1.0",


### PR DESCRIPTION
In done-ssr we cleanup memory by calling
`domMutate.removeChild.call(document, document.documentElement)`. When
an element's removal callback is called in can-view-live it was checking
if it is within the documentElement. Since there is no document element,
   this was throwing.

The fix is to prefer document.contains(). Closes #123