### PR TITLE
Queue all DOM updates in the dom queue

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -102,7 +102,7 @@ module.exports = {
 			var parentNode = range.start.parentNode,
 				cur = range.end.previousSibling,
 				remove;
-			while(cur !== range.start) {
+			while(cur && cur !== range.start) {
 				remove = cur;
 				cur = cur.previousSibling;
 				domMutateNode.removeChild.call(parentNode, remove );
@@ -113,10 +113,11 @@ module.exports = {
 
 		update: function ( range, frag ) {
 			var parentNode = range.start.parentNode;
-
-			domMutateNode.insertBefore.call(parentNode, frag, range.end);
-			// this makes it so `connected` events will be called immediately
-			domMutate.flushRecords();
+			if(parentNode) {
+				domMutateNode.insertBefore.call(parentNode, frag, range.end);
+				// this makes it so `connected` events will be called immediately
+				domMutate.flushRecords();
+			}
 		}
 	},
 	ListenUntilRemovedAndInitialize: ListenUntilRemovedAndInitialize,

--- a/lib/html.js
+++ b/lib/html.js
@@ -79,7 +79,6 @@ module.exports = function(el, compute, viewInsertSymbolOptions) {
 	// replace element with a comment node
 	var range = helpers.range.create(el, observableName);
 
-	var meta = {reasonLog: "live.html replace::"+observableName, element: range.start};
 	var useQueue = false;
 	new helpers.ListenUntilRemovedAndInitialize(compute,
 		function canViewLive_updateHTML(val) {
@@ -102,14 +101,14 @@ module.exports = function(el, compute, viewInsertSymbolOptions) {
 
 			if(useQueue === true) {
 				helpers.range.remove(range);
-				queues.domQueue.enqueue(updateRange, null, [range, frag], meta);
+				updateRange(range, frag);
 			} else {
 				helpers.range.update(range, frag);
 				useQueue = true;
 			}
 		},
 		range.start,
-		"notify",
+		"dom",
 		"live.html replace::" + observableName, doNotUpdateRange);
 
 };

--- a/lib/list.js
+++ b/lib/list.js
@@ -141,8 +141,8 @@ ListDOMPatcher.prototype = {
 			return;
 		}
 		var sortedPatches = [];
-		patches.forEach(patch => {
-			sortedPatches.push(...patchSort([patch]));
+		patches.forEach(function(patch) {
+			sortedPatches.push.apply(sortedPatches, patchSort([patch]));
 		});
 		// adjust so things can happen
 		for (var i = 0, patchLen = sortedPatches.length; i < patchLen; i++) {
@@ -169,15 +169,17 @@ ListDOMPatcher.prototype = {
 	},
 	addToDomQueue: function(fn, args) {
 		this.domQueue.push({
-			fn,
-			args
+			fn: fn,
+			args: args
 		});
 		queues.domQueue.enqueue(this.processDomQueue, this, [this.domQueue], this.meta);
 	},
 	processDomQueue: function() {
-		this.domQueue.forEach(({ fn, args }) => {
+		this.domQueue.forEach(function(queueItem) {
+			var fn = queueItem.fn;
+			var args = queueItem.args;
 			fn.apply(this, args);
-		});
+		}.bind(this));
 		this.domQueue = [];
 	},
 	add: function(items, index) {

--- a/lib/list.js
+++ b/lib/list.js
@@ -73,11 +73,15 @@ function ListDOMPatcher(el, compute, render, context, falseyRender) {
 	// A mapping of each item's end node
 	this.itemEndNode = [];
 
+	// A mapping of each item to its pending patches.
+	this.domQueue = [];
+
 	this.isValueLike = canReflect.isValueLike(this.value);
 	this.isObservableLike = canReflect.isObservableLike(this.value);
 
 	// Setup binding and teardown to add and remove events
 	this.onPatches = this.onPatches.bind(this);
+	this.processDomQueue = this.processDomQueue.bind(this);
 	this.teardownValueBinding = this.teardownValueBinding.bind(this);
 
 	this.meta = {reasonLog: "live.html add::"+observableName, element: this.range.start};
@@ -136,29 +140,45 @@ ListDOMPatcher.prototype = {
 		if (this.exit) {
 			return;
 		}
-		var sortedPatches = patchSort(patches);
+		var sortedPatches = [];
+		patches.forEach(patch => {
+			sortedPatches.push(...patchSort([patch]));
+		});
 		// adjust so things can happen
 		for (var i = 0, patchLen = sortedPatches.length; i < patchLen; i++) {
 			var patch = sortedPatches[i];
 			if (patch.type === "move") {
-				this.move(patch.toIndex, patch.fromIndex);
+				this.addToDomQueue(
+					this.move,
+					[patch.toIndex, patch.fromIndex]
+				);
 			} else {
 				if (patch.deleteCount) {
 					// Remove any items scheduled for deletion from the patch.
-					this.remove({
+					this.addToDomQueue(this.remove, [{
 						length: patch.deleteCount
-					}, patch.index, true);
+					}, patch.index]);
 				}
 				if (patch.insert && patch.insert.length) {
 					// Insert any new items at the index
-					this.addInDomQueue(patch.insert, patch.index);
+					this.addToDomQueue(this.add, [patch.insert, patch.index]);
 				}
 			}
 
 		}
 	},
-	addInDomQueue: function(items, index) {
-		queues.domQueue.enqueue(this.add, this, [items, index], this.meta);
+	addToDomQueue: function(fn, args) {
+		this.domQueue.push({
+			fn,
+			args
+		});
+		queues.domQueue.enqueue(this.processDomQueue, this, [this.domQueue], this.meta);
+	},
+	processDomQueue: function() {
+		this.domQueue.forEach(({ fn, args }) => {
+			fn.apply(this, args);
+		});
+		this.domQueue = [];
 	},
 	add: function(items, index) {
 		//if (!afterPreviousEvents) {
@@ -253,7 +273,9 @@ ListDOMPatcher.prototype = {
 
 		this.itemEndNode.splice(index, items.length);
 
-		helpers.range.remove({start: removeStart, end: removeEnd});
+		if (removeStart && removeEnd) {
+			helpers.range.remove({start: removeStart, end: removeEnd});
+		}
 
 		var indexMap = this.indexMap;
 
@@ -347,12 +369,6 @@ ListDOMPatcher.prototype = {
 			// set each compute to have its current index in the map as its value
 			indexMap[i].set(i);
 		}
-	},
-	set: function(newVal, index) {
-		this.remove({
-			length: 1
-		}, index, true);
-		this.add([newVal], index);
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "detect-cyclic-packages": "^1.1.0",
     "http-server": "^0.10.0",
     "jshint": "^2.9.1",
-    "steal": "^2.2.4",
+    "steal": "^1.12.6",
     "steal-qunit": "^2.0.0",
     "test-saucelabs": "0.0.6",
     "testee": "^0.9.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "detect-cyclic-packages": "^1.1.0",
     "http-server": "^0.10.0",
     "jshint": "^2.9.1",
-    "steal": "^1.2.10",
+    "steal": "^2.2.4",
     "steal-qunit": "^2.0.0",
     "test-saucelabs": "0.0.6",
     "testee": "^0.9.0"

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -179,10 +179,10 @@ testHelpers.dev.devOnlyTest('can-reflect-dependencies', function(assert) {
 		canReflectDeps
 			.getDependencyDataOf(html)
 			.whatIChange
-			.derive
+			.mutate
 			.valueDependencies,
 		new Set([div.firstChild]),
-		'whatChangesMe(<observation>) shows the div'
+		'whatIChange(<observation>) shows the div'
 	);
 
 	var undo = domMutate.onNodeDisconnected(div, function checkTeardown () {


### PR DESCRIPTION
* For live.list, queue all removes and adds in the ListDOMPatcher together, and perform removes and adds when the dom queue is flushed.
* For live.html, move updates from the notify queue to the dom queue; do adds right after removes when queue is flushing, rather than enqueuing again.
* Add guards to the range helpers so they do not attempt to iterate removals on ranges that have already been torn down (i.e. when the start and end nodes no longer have parents nor siblings)
* do patch sort on each patch passed into live.list rather than attempting to sort all patches (prevents "Could not group patches" error when 3 or more patches are dispatched)

Closes #150 