### PR TITLE
Re-bind placeholder nodes after they reconnect to the document

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,6 +5,7 @@ var canReflect = require("can-reflect");
 var canReflectDeps = require('can-reflect-dependencies');
 var parser = require('can-view-parser');
 var canDev = require("can-log/dev/dev");
+var isConnected = require("can-dom-mutate/-is-connected");
 
 var setElementSymbol = canSymbol.for("can.setElement");
 var elementSymbol = canSymbol.for("can.element");
@@ -54,7 +55,7 @@ ListenUntilRemovedAndInitialize.prototype.setup = function() {
 	// reinsertion case, not applicable during initial setup
 	if(this.setupNodeReinserted) {
 		// do not set up again if disconnected
-		if(!this.placeholder.isConnected) {
+		if(!isConnected.isConnected(this.placeholder)) {
 			return;
 		}
 		this.setupNodeReinserted();
@@ -75,7 +76,7 @@ ListenUntilRemovedAndInitialize.prototype.setup = function() {
 };
 ListenUntilRemovedAndInitialize.prototype.teardown = function(){
 	// do not teardown if still connected.
-	if(this.placeholder.isConnected) {
+	if(isConnected.isConnected(this.placeholder)) {
 		return;
 	}
 	this.teardownNodeRemoved();

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -9,13 +9,18 @@ var canDev = require("can-log/dev/dev");
 var setElementSymbol = canSymbol.for("can.setElement");
 var elementSymbol = canSymbol.for("can.element");
 
-function ListenUntilRemovedAndInitialize(observable, handler, placeholder, queueName, handlerName, afterTeardownNodeRemoved) {
+function ListenUntilRemovedAndInitialize(
+	observable,
+	handler,
+	placeholder,
+	queueName,
+	handlerName
+) {
 	this.observable = observable;
 	this.handler = handler;
 	this.placeholder = placeholder;
 	this.queueName = queueName;
 	this.handler[elementSymbol] = placeholder;
-	this.afterTeardownNodeRemoved = afterTeardownNodeRemoved;
 
 	if( observable[setElementSymbol] ) {
 		observable[setElementSymbol](placeholder);
@@ -40,24 +45,42 @@ function ListenUntilRemovedAndInitialize(observable, handler, placeholder, queue
 			value: handlerName,
 		});
 
-		canReflectDeps.addMutatedBy(placeholder, observable);
 	}
 	//!steal-remove-end
 
-	this.teardownNodeRemoved = domMutate.onNodeRemoved(placeholder,
+	this.setup();
+}
+ListenUntilRemovedAndInitialize.prototype.setup = function() {
+	// reinsertion case, not applicable during initial setup
+	if(this.setupNodeReinserted) {
+		// do not set up again if disconnected
+		if(!this.placeholder.isConnected) {
+			return;
+		}
+		this.setupNodeReinserted();
+	}
+	this.teardownNodeRemoved = domMutate.onNodeRemoved(this.placeholder,
 		this.teardown.bind(this));
 
-	canReflect.onValue(observable, handler, queueName);
 
-	// data = live.listen(parentNode, compute, liveHTMLUpdateHTML);
-	handler(  canReflect.getValue(observable) );
-}
-ListenUntilRemovedAndInitialize.prototype.teardown = function(){
-	this.teardownNodeRemoved();
-
-	if (this.afterTeardownNodeRemoved) {
-		this.afterTeardownNodeRemoved();
+	//!steal-remove-start
+	if(process.env.NODE_ENV !== 'production') {
+		canReflectDeps.addMutatedBy(this.placeholder, this.observable);
 	}
+	//!steal-remove-end
+
+	canReflect.onValue(this.observable, this.handler, this.queueName);
+	this.handler(  canReflect.getValue(this.observable) );
+
+};
+ListenUntilRemovedAndInitialize.prototype.teardown = function(){
+	// do not teardown if still connected.
+	if(this.placeholder.isConnected) {
+		return;
+	}
+	this.teardownNodeRemoved();
+	this.setupNodeReinserted = domMutate.onNodeInserted(this.placeholder,
+		this.setup.bind(this));
 
 	//!steal-remove-start
 	if(process.env.NODE_ENV !== 'production') {

--- a/lib/html.js
+++ b/lib/html.js
@@ -65,10 +65,6 @@ module.exports = function(el, compute, viewInsertSymbolOptions) {
 	}
 	//!steal-remove-end
 
-	var doNotUpdateRange = function() {
-		queues.domQueue.dequeue(updateRange);
-	};
-
 	if (el.nodeType !== Node.COMMENT_NODE) {
 		var commentFrag = makeCommentFragment(observableName);
 		var startCommentNode = commentFrag.firstChild;
@@ -109,6 +105,6 @@ module.exports = function(el, compute, viewInsertSymbolOptions) {
 		},
 		range.start,
 		"dom",
-		"live.html replace::" + observableName, doNotUpdateRange);
+		"live.html replace::" + observableName);
 
 };

--- a/lib/html.js
+++ b/lib/html.js
@@ -3,7 +3,6 @@
 var makeFragment = require('can-fragment');
 var canReflect = require('can-reflect');
 var canSymbol = require("can-symbol");
-var queues = require("can-queues");
 var helpers = require('./helpers');
 var getDocument = require('can-globals/document/document');
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "can-attribute-observable": "^2.0.0",
     "can-child-nodes": "^1.0.0",
     "can-diff": "^1.5.0",
-    "can-dom-mutate": "^2.0.0",
+    "can-dom-mutate": "^2.0.8",
     "can-fragment": "^1.0.0",
     "can-observation": "^4.2.0",
     "can-queues": "^1.3.0",

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -327,6 +327,6 @@ QUnit.test('Live binding is restored when the placeholder is reconnected', funct
 			console.log(	document.getElementById("qunit-fixture").innerHTML);
 			assert.equal(div.getElementsByTagName('label').length, 3);
 			done();
-		})
+		});
 	});
 });

--- a/test/html-test.js
+++ b/test/html-test.js
@@ -311,7 +311,7 @@ QUnit.test('Live binding is restored when the placeholder is reconnected', funct
 	});
 	live.html(span, html);
 	assert.equal(div.getElementsByTagName('label').length, 2);
-	var commentChildren = Array.from(div.childNodes).filter(function(node) {
+	var commentChildren = [].slice.call(div.childNodes, 0).filter(function(node) {
 		return node.nodeType === Node.COMMENT_NODE;
 	});
 	div.removeChild(commentChildren[0]);

--- a/test/text-test.js
+++ b/test/text-test.js
@@ -165,7 +165,7 @@ QUnit.test('Live binding is restored when the text node is reconnected', functio
 				assert.equal(div.innerHTML, 'four');
 
 				done();
-			})
+			});
 		});
 	});
 });


### PR DESCRIPTION
Sometimes users will move component markup around in the DOM.  A reduced example can be seen here: https://codepen.io/bmomberger-bitovi/pen/bGNYvBg?editors=1010

The underlying reason for this is that can-view-live tears down live binding on placeholders when those placeholders are removed from the document.  But this also breaks live binding on nodes which are just getting shuffled around by other code.  This can happen with jQuery plugins and other mutating libraries that happen to work alongside CanJS.

This PR addresses this possibility by letting removed placeholder nodes re-bind if they are later added to the document.